### PR TITLE
WalletName.ToString method fixed

### DIFF
--- a/QBitNinja/Models/BalanceSelector.cs
+++ b/QBitNinja/Models/BalanceSelector.cs
@@ -21,7 +21,7 @@ namespace QBitNinja.Client.Models
 		string _Name;
 		public override string ToString()
 		{
-			return base.ToString();
+			return _Name.ToString();
 		}
 	}
 	public class BalanceSelector


### PR DESCRIPTION
BalanceSelector couldn't set wallet name correctly because of this issue. So any client api method like client.GetBalance(walletname) is failing because of this issue. 

https://github.com/YakupIpek/QBitNinja/blob/6843958dd68ba505a15f38d944539a29ba60423b/QBitNinja/Models/BalanceSelector.cs#L42